### PR TITLE
protected route to dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import SignIn from './pages/SignIn';
 import About from './pages/About';
 import SuggestionBox from './pages/SuggestionBox';
 import ChatDetail from './pages/ChatDetail';
+import ProtectedRoute from './components/ProtectedRoute';
 import './App.css';
 
 function App() {
@@ -13,7 +14,11 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Landing />} />
-        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/dashboard" element={
+          <ProtectedRoute>
+              <Dashboard />
+          </ProtectedRoute>
+          } />
         <Route path="/signup" element={<SignUp />} />
         <Route path="/signin" element={<SignIn />} />
         <Route path="/about" element={<About />} />

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/NavBar.css';
 import logo from '../assets/logo.svg'
+import { signOut } from '../lib/session.ts';
 
 interface NavBarProps {
   onSearch: (searchTerm: string) => void;
@@ -45,7 +46,7 @@ const NavBar: React.FC<NavBarProps> = ({ onSearch }) => {
             src="/logout.svg" 
             alt="LogOut" 
             className="logout" 
-            onClick={() => navigate('/')}
+            onClick={() => signOut()}
             style={{ cursor: 'pointer' }}
           />
         </div>

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,0 +1,32 @@
+import { Navigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+
+interface ProtectedRouteProps {
+    children: React.ReactNode;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+    const [loading, setLoading] = useState<any|null>(true);
+    const [user, setUser] = useState<any|null>(null);
+
+    useEffect(() => {
+        const getSession = async () => {
+            const { data: { session } } = await supabase.auth.getSession();
+            setUser(session?.user || null);
+            setLoading(false);
+        };
+        getSession();
+    }, []);
+
+    if (loading) {
+        return <div>Loading... Make sure to be signed in/up!</div>;
+    }
+    if (!user) {
+        return <Navigate to="/" replace />;
+    }
+
+    return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/client/src/lib/session.ts
+++ b/client/src/lib/session.ts
@@ -36,6 +36,7 @@ export async function signIn(email: string, password: string) {
 
 export async function signOut() {
     const { error } = await supabase.auth.signOut();
+    alert("signed out");
     if (error) {
         alert("Error signing out: " + error.message);
         return null;

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import {supabase} from '../lib/supabase';
 
 
 const Dashboard: React.FC = () => {
+
     const [user, setUser] = useState<any|null>(null);
 
     useEffect(() => {


### PR DESCRIPTION
Created protectedRoute component such that its children components/pages are only visible when logged in.

Currently, only route to dashboard is protected:
If logged in, will route to dashboard
If not logged in, will route back to landing page (no error/tip page for confused users though)

Also linked log out button to session.ts signOut()